### PR TITLE
Add vxlan dependency

### DIFF
--- a/roles/access-point/tasks/main.yml
+++ b/roles/access-point/tasks/main.yml
@@ -37,6 +37,7 @@
       - frr-vtysh
       - frr-watchfrr
       - frr-staticd
+      - luci-proto-vxlan
       - prometheus-node-exporter-lua
       - prometheus-node-exporter-lua-netstat
       - prometheus-node-exporter-lua-openwrt


### PR DESCRIPTION
Currently, the vxlan module is not installed, causing the netlink calls to create VXLANs to fail. This PR adds the package to the list of installed packages on the APs. 