### PR TITLE
Add a readme for binary folders

### DIFF
--- a/roles/access-point/files/linksys/README.md
+++ b/roles/access-point/files/linksys/README.md
@@ -1,0 +1,3 @@
+# Linksys Binary folder
+
+Please place the binary for your Linksys APs here

--- a/roles/access-point/files/zyxel/README.md
+++ b/roles/access-point/files/zyxel/README.md
@@ -1,0 +1,3 @@
+# ZyXel Binary folder
+
+Please place the binary for your ZyXel APs here


### PR DESCRIPTION
Currently, the folders for the binary files are not part of the repo since there is no tracked file inside of them. 
To make it more understandable how to add binaries for each architecture, these folders should be automatically created on clone. This is achieved by placing a README.md in each of these folders