### PR TITLE
Allow configuring the gateway as a RR

### DIFF
--- a/example-inventory.yml
+++ b/example-inventory.yml
@@ -13,6 +13,9 @@ bgp:
               uplink_if: eth0
               #  Which interface is supposed to listen for the wimoved network
               wimove_if: eth0
+              # Set to true if the gateway should also act as a Route Reflector.
+              # When set, you need to remove all hosts from the routeReflectors group
+              is_route_reflector: false
         routeReflectors:
           hosts:
             route-reflector:

--- a/example-inventory.yml
+++ b/example-inventory.yml
@@ -13,9 +13,7 @@ bgp:
               uplink_if: eth0
               #  Which interface is supposed to listen for the wimoved network
               wimove_if: eth0
-              # Set to true if the gateway should also act as a Route Reflector.
-              # When set, you need to remove all hosts from the routeReflectors group
-              is_route_reflector: false
+              # When you want to combine the RR and gateway into one device, simply place the same host in both groups
         routeReflectors:
           hosts:
             route-reflector:

--- a/install.yml
+++ b/install.yml
@@ -15,6 +15,10 @@
   name: "Configure gateway"
   roles:
     - gateway
+- hosts: gateways:&routeReflectors
+  name: "Configure combined gateway and route reflector"
+  roles:
+    - combined
 - hosts: openwrt
   roles:
     - access-point

--- a/roles/combined/handlers/main.yml
+++ b/roles/combined/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Restart host
+  become: true
+  ansible.builtin.reboot:

--- a/roles/combined/tasks/main.yml
+++ b/roles/combined/tasks/main.yml
@@ -1,0 +1,7 @@
+- name: "Copy frr configuration"
+  become: true
+  ansible.builtin.template:
+    src: "templates/frr/frr.conf.j2"
+    dest: "/etc/frr/frr.conf"
+  notify:
+    - Restart host

--- a/roles/combined/templates/frr/frr.conf.j2
+++ b/roles/combined/templates/frr/frr.conf.j2
@@ -12,15 +12,19 @@ ip nht resolve-via-default
 ip6 nht resolve-via-default
 router bgp 65000
   bgp router-id {{ ip }}
+  bgp cluster-id {{ ip }}
+  bgp log-neighbor-changes
   no bgp default ipv4-unicast
   neighbor fabric peer-group
   neighbor fabric remote-as 65000
   neighbor fabric capability extended-nexthop
   neighbor fabric ebgp-multihop 5
   neighbor {{ route_reflector_ip }} peer-group fabric
+  bgp listen range {{ listen_range }} peer-group fabric
 
   address-family l2vpn evpn
    neighbor fabric activate
+   neighbor fabric route-reflector-client
    advertise-all-vni
    advertise-svi-ip
   exit-address-family

--- a/roles/gateway/templates/frr/frr.conf.j2
+++ b/roles/gateway/templates/frr/frr.conf.j2
@@ -12,16 +12,28 @@ ip nht resolve-via-default
 ip6 nht resolve-via-default
 router bgp 65000
   bgp router-id {{ ip }}
+{% if is_route_reflector %}
+! RR configuration
+  bgp cluster-id {{ ip }}
+  bgp log-neighbor-changes
+{% endif %}
   no bgp default ipv4-unicast
   neighbor fabric peer-group
   neighbor fabric remote-as 65000
   neighbor fabric capability extended-nexthop
   neighbor fabric ebgp-multihop 5
-  ! BGP sessions with route reflectors
   neighbor {{ route_reflector_ip }} peer-group fabric
-  !
+{% if is_route_reflector %}
+! Listen since this is also a RR
+  bgp listen range {{ listen_range }} peer-group fabric
+{% endif %}
+
   address-family l2vpn evpn
    neighbor fabric activate
+{% if is_route_reflector %}
+! RR configuration
+   neighbor fabric route-reflector-client
+{% endif %}
    advertise-all-vni
    advertise-svi-ip
   exit-address-family


### PR DESCRIPTION
Using the provided option, the functions of the RR can be included in the gateway, thus requiring one less server for a deployment. 

When merging, please also update the [Documentation](https://github.com/WiMoVE-OSS/docs/pull/1) to reflect this. 

https://github.com/WiMoVE-OSS/docs/pull/1