### PR TITLE
Run sysctl commands as root

### DIFF
--- a/roles/gateway/tasks/main.yml
+++ b/roles/gateway/tasks/main.yml
@@ -18,19 +18,19 @@
     name: net.ipv4.ip_forward
     value: 1
     sysctl_set: yes
-- name: Enable IPv4 forwarding
+- name: Enable IPv6 forwarding
   become: true
   ansible.posix.sysctl:
     name: net.ipv6.conf.all.forwarding
     value: '1'
     sysctl_set: yes
-- name: Enable IPv4 forwarding
+- name: Enable strict ARP
   become: true
   ansible.posix.sysctl:
     name: net.ipv4.conf.all.arp_ignore
     value: '1'
     sysctl_set: yes
-- name: Enable IPv4 forwarding
+- name: Configure strict ARP
   become: true
   ansible.posix.sysctl:
     name: net.ipv4.conf.all.arp_announce

--- a/roles/gateway/tasks/main.yml
+++ b/roles/gateway/tasks/main.yml
@@ -12,19 +12,27 @@
     dest: "/etc/frr/frr.conf"
   notify:
     - Restart frr
-- ansible.posix.sysctl:
+- name: Enable IPv4 forwarding
+  become: true
+  ansible.posix.sysctl:
     name: net.ipv4.ip_forward
-    value: '1'
+    value: 1
     sysctl_set: yes
-- ansible.posix.sysctl:
+- name: Enable IPv4 forwarding
+  become: true
+  ansible.posix.sysctl:
     name: net.ipv6.conf.all.forwarding
     value: '1'
     sysctl_set: yes
-- ansible.posix.sysctl:
+- name: Enable IPv4 forwarding
+  become: true
+  ansible.posix.sysctl:
     name: net.ipv4.conf.all.arp_ignore
     value: '1'
     sysctl_set: yes
-- ansible.posix.sysctl:
+- name: Enable IPv4 forwarding
+  become: true
+  ansible.posix.sysctl:
     name: net.ipv4.conf.all.arp_announce
     value: '2'
     sysctl_set: yes


### PR DESCRIPTION
To complete the setup successfully, we must run the sysctl configuration with root privileges. 